### PR TITLE
Add Safari WebViews

### DIFF
--- a/GitHub/Base.lproj/Main.storyboard
+++ b/GitHub/Base.lproj/Main.storyboard
@@ -432,11 +432,15 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6qA-im-dFI">
                                 <rect key="frame" x="0.0" y="64" width="320" height="221"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bMf-Sj-U5A">
+                                    <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bMf-Sj-U5A">
                                         <rect key="frame" x="20" y="20" width="292" height="20.5"/>
+                                        <gestureRecognizers/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                         <color key="textColor" red="0.01176470588" green="0.40000000000000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
+                                        <connections>
+                                            <outletCollection property="gestureRecognizers" destination="RmV-nP-exH" appends="YES" id="8cy-BE-brt"/>
+                                        </connections>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kc2-Db-wbb">
                                         <rect key="frame" x="20" y="48.5" width="292" height="20.5"/>
@@ -524,6 +528,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rFF-ub-URp" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="RmV-nP-exH" userLabel="tapRepoName">
+                    <connections>
+                        <action selector="repoNameWasTapped:" destination="1tm-D1-AnM" id="qyO-e6-TQL"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2649.375" y="-1307.7464788732395"/>
         </scene>

--- a/GitHub/Base.lproj/Main.storyboard
+++ b/GitHub/Base.lproj/Main.storyboard
@@ -397,10 +397,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kru-gf-pWJ">
-                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
-                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </webView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="j2H-9F-Knn">
                                 <rect key="frame" x="141.5" y="265.5" width="37" height="37"/>
                                 <color key="color" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
@@ -408,23 +404,18 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="kru-gf-pWJ" firstAttribute="top" secondItem="uT2-no-tMd" secondAttribute="bottom" id="CZe-YH-Bdm"/>
-                            <constraint firstItem="loQ-FK-Cty" firstAttribute="top" secondItem="kru-gf-pWJ" secondAttribute="bottom" id="Cpa-rE-FDL"/>
                             <constraint firstItem="j2H-9F-Knn" firstAttribute="centerY" secondItem="8FP-xm-lFN" secondAttribute="centerY" id="HX0-SX-h9h"/>
-                            <constraint firstAttribute="trailing" secondItem="kru-gf-pWJ" secondAttribute="trailing" id="fHD-Xe-shG"/>
-                            <constraint firstItem="kru-gf-pWJ" firstAttribute="leading" secondItem="8FP-xm-lFN" secondAttribute="leading" id="uHV-o3-pB6"/>
                             <constraint firstItem="j2H-9F-Knn" firstAttribute="centerX" secondItem="8FP-xm-lFN" secondAttribute="centerX" id="vpF-wz-I1o"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="loadingIndicator" destination="j2H-9F-Knn" id="p26-L3-lDG"/>
-                        <outlet property="webView" destination="kru-gf-pWJ" id="rjd-XP-ulQ"/>
                         <segue destination="49e-Tb-3d3" kind="show" identifier="ShortTabViewController" id="Fit-OF-54B"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="k66-a2-qyS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1131" y="119"/>
+            <point key="canvasLocation" x="-1633" y="118"/>
         </scene>
         <!--Repository View Controller-->
         <scene sceneID="Suf-U1-sgz">

--- a/GitHub/Controllers/AuthenticationViewController.swift
+++ b/GitHub/Controllers/AuthenticationViewController.swift
@@ -16,7 +16,7 @@ class AuthenticationViewController: UIViewController, UIWebViewDelegate {
     super.viewDidLoad()
     webView.delegate = self
 
-    if let authRequest = GitHubAPI.shared.getAuthenticationRequest() {
+    if let authRequest = GitHubAPI.shared.buildAuthenticationRequest() {
       webView.loadRequest(authRequest)
     }
   }

--- a/GitHub/Controllers/AuthenticationViewController.swift
+++ b/GitHub/Controllers/AuthenticationViewController.swift
@@ -6,22 +6,30 @@
 //  Copyright © 2017 Jake Romer. All rights reserved.
 //
 
+import SafariServices
 import UIKit
 
-class AuthenticationViewController: UIViewController, UIWebViewDelegate {
-  @IBOutlet weak var webView: UIWebView!
+class AuthenticationViewController: UIViewController, SFSafariViewControllerDelegate {
   @IBOutlet weak var loadingIndicator: UIActivityIndicatorView!
+
+  var safari: SFSafariViewController!
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    webView.delegate = self
 
-    if let authRequest = GitHubAPI.shared.buildAuthenticationRequest() {
-      webView.loadRequest(authRequest)
+    if let authRequest = GitHubAPI.shared.buildAuthenticationRequest(),
+      let url = authRequest.url {
+      safari = SFSafariViewController(url: url)
+      safari.delegate = self
     }
   }
 
-  func webViewDidFinishLoad(_ webView: UIWebView) {
+  override func viewDidAppear(_ animated: Bool) {
+    guard let safari = safari else { return }
+    present(safari, animated: true, completion: nil)
+  }
+
+  func safariViewController(_ controller: SFSafariViewController, didCompleteInitialLoad didLoadSuccessfully: Bool) {
     loadingIndicator.stopAnimating()
   }
 }

--- a/GitHub/Controllers/ExploreViewController.swift
+++ b/GitHub/Controllers/ExploreViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SafariServices
 
 class ExploreViewController: UIViewController {
   // MARK: IBOutlets
@@ -120,6 +121,14 @@ extension ExploreViewController: UICollectionViewDelegate, UICollectionViewDataS
                                                   for: indexPath) as! UserSearchResultCell
     cell.user = users[indexPath.row]
     return cell
+  }
+
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    let selectedUser = users[indexPath.row]
+    if let url = URL(string: selectedUser.urlHTML) {
+      let safariVC = SFSafariViewController(url: url)
+      present(safariVC, animated: true, completion: nil)
+    }
   }
 }
 

--- a/GitHub/Controllers/ExploreViewController.swift
+++ b/GitHub/Controllers/ExploreViewController.swift
@@ -60,7 +60,8 @@ class ExploreViewController: UIViewController {
 // TODO: Add pull-to-refresh, pagination, loading indicator
 extension ExploreViewController: UISearchBarDelegate {
   func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-    guard let searchQuery = searchBar.text else { return }
+    guard let searchQuery = searchBar.text?.sanitized()
+      else { return }
 
     switch segmentedControl.selectedSegmentIndex {
     case 0:

--- a/GitHub/Controllers/HomeViewController.swift
+++ b/GitHub/Controllers/HomeViewController.swift
@@ -117,7 +117,7 @@ extension HomeViewController: UISearchBarDelegate {
       inSearchMode = false
     } else {
       inSearchMode = true
-      let searchTerm = searchText.lowercased()
+      let searchTerm = searchText.sanitized()
       filteredRepositories = allRepositories.filter { $0.fullName.lowercased().range(of: searchTerm) != nil }
     }
     tableView.reloadData()

--- a/GitHub/Controllers/RepositoryViewController.swift
+++ b/GitHub/Controllers/RepositoryViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SafariServices
 
 class RepositoryViewController: UIViewController {
   var repository: Repository?
@@ -33,6 +34,13 @@ class RepositoryViewController: UIViewController {
       repoForks.text = "Forks: \(repository.forksCount)"
       repoIsFork.text = repository.isFork ? "fork of" : ""
       repoCreatedAt.text = "Created: \(repository.createdAt.toString())"
+    }
+  }
+
+  @IBAction func repoNameWasTapped(_ sender: UITapGestureRecognizer) {
+    if let urlString = repository?.urlHTML, let url = URL(string: urlString) {
+      let safariVC = SFSafariViewController(url: url, entersReaderIfAvailable: true)
+      present(safariVC, animated: true, completion: nil)
     }
   }
 }

--- a/GitHub/Models/GitHubAPI.swift
+++ b/GitHub/Models/GitHubAPI.swift
@@ -213,7 +213,7 @@ class GitHubAPI {
 
   // MARK: Authentication, Authorization
   /// Build a URLRequest for requesting an authentication code
-  func getAuthenticationRequest() -> URLRequest? {
+  func buildAuthenticationRequest() -> URLRequest? {
     let scopes = [
       "repo",
       "user",

--- a/GitHub/Utilities/String.swift
+++ b/GitHub/Utilities/String.swift
@@ -9,6 +9,11 @@
 import Foundation
 
 extension String {
+  func sanitized() -> String {
+    let term = scan("[:word:]+").joined(separator: " ")
+    return term.lowercased()
+  }
+
   func scan(_ regex: String) -> [String] {
     do {
       let regex = try NSRegularExpression(pattern: regex)


### PR DESCRIPTION
- Adds a [gesture recognizer](https://github.com/jkrmr/GitHub/pull/5/files#diff-8a2259c8d57b9813dd407341d741e4c1R40) to the repository name on RepoViewController that loads a SafariViewController for the associated repository
- Uses a [regex to sanitize user input](https://github.com/jkrmr/GitHub/pull/5/files#diff-6bfbb963cb442d621ec5fee11e338b91R12) into UISearchBars 
- the HomeViewController is embedded in a TabBarController.
- The user search segment of the Explore tab allows for user searches 
- Displays a UICollectionView to display the avatar images for user search results.
- Upon clicking one of the UICollectionViewCells, a web view displays the user's GitHub profile

<div align="center">
  <img src="https://cloud.githubusercontent.com/assets/4433943/24774066/601e16c8-1acc-11e7-889b-3aff83923a8c.gif" >
</div>